### PR TITLE
check if EDD_USE_PHP_SESSIONS is already defined

### DIFF
--- a/class-edd-sl-api-endpoint.php
+++ b/class-edd-sl-api-endpoint.php
@@ -19,8 +19,10 @@ if( stristr( $_SERVER['REQUEST_URI'], '/edd-sl-api' ) !== false ) {
 			// disable cronjobs for this request
 			define('DISABLE_WP_CRON', true);
 
-			// prevent session query caused by EDD
-			define( 'EDD_USE_PHP_SESSIONS', true );
+			// prevent session query caused by EDD if not set already
+			if( ! defined( 'EDD_USE_PHP_SESSIONS' ) ) {
+				define( 'EDD_USE_PHP_SESSIONS', true );
+			}
 
 			// filter active plugins
 			add_filter( 'option_active_plugins', array( $this, 'filter_active_plugins' ) );


### PR DESCRIPTION
Prevents the `PHP Notice:  Constant EDD_USE_PHP_SESSIONS already defined` warning when the constant is set in wp-config.php